### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -7,7 +7,7 @@ bytecode
 * `bytecode project homepage at GitHub
   <https://github.com/haypo/bytecode>`_ (code, bugs)
 * `bytecode documentation
-  <https://bytecode.readthedocs.org/>`_
+  <https://bytecode.readthedocs.io/>`_
 * `Download latest bytecode release at the Python Cheeseshop (PyPI)
   <https://pypi.python.org/pypi/bytecode>`_
 

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -63,7 +63,7 @@ Bugfixes:
 
 - Again, the API is deeply reworked.
 - The project has now a documentation:
-  `bytecode documentation <https://bytecode.readthedocs.org/>`_
+  `bytecode documentation <https://bytecode.readthedocs.io/>`_
 - Fix bug #1: support jumps larger than 2^16.
 - Add a new :ref:`bytecode.peephole_opt module <peephole_opt>`: a peephole
   optimizer, code based on peephole optimizer of CPython 3.6 which is

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -7,7 +7,7 @@ bytecode
 * `bytecode project homepage at GitHub
   <https://github.com/haypo/bytecode>`_ (code, bugs)
 * `bytecode documentation
-  <https://bytecode.readthedocs.org/>`_ (this documentation)
+  <https://bytecode.readthedocs.io/>`_ (this documentation)
 * `Download latest bytecode release at the Python Cheeseshop (PyPI)
   <https://pypi.python.org/pypi/bytecode>`_
 


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.