### PR TITLE
Add stack depth computation

### DIFF
--- a/bytecode/concrete.py
+++ b/bytecode/concrete.py
@@ -495,7 +495,7 @@ class ConcreteBytecode(_bytecode.BaseBytecode, list):
 
                 if last_popped_block == _BlockType.WITH_BLOCK:
                     next_stack = next_stack[:-1] + (next_stack[-1] - 1,)
-                op += [_StackState(self,  jump_targets[id(o)], next_stack,
+                op += [_StackState(self, jump_targets[id(o)], next_stack,
                                    next_block_stack, log, logging)]
 
             elif o_name == 'SETUP_LOOP':

--- a/bytecode/concrete.py
+++ b/bytecode/concrete.py
@@ -522,9 +522,8 @@ class ConcreteBytecode(_bytecode.BaseBytecode, list):
 
             elif o_name == 'SETUP_EXCEPT':
                 # We continue with a new block.
-                # On exception, we jump to the label with 3 extra objects on
-                # stack
-                # FIXME : why use 6 here ?
+                # On exception, we jump to the label with 6 extra objects on
+                # stack.
                 inside_except_log = cur_state.newlog("SETUP_EXCEPT, "
                                                      "exception (+6, +block)")
                 inside_try_log = cur_state.newlog("SETUP_EXCEPT, "

--- a/bytecode/instr.py
+++ b/bytecode/instr.py
@@ -318,3 +318,21 @@ class Instr:
         if self.is_uncond_jump():
             return True
         return False
+
+    def has_flow(self):
+        """
+
+        """
+        # WITH_CLEANUP is used only for python < (3, 5)
+        # WITH_CLEANUP_START, WITH_CLEANUP_FINISH, SETUP_ASYNC_WITH are used
+        # only for python >= (3, 5)
+        if self._name in {'POP_BLOCK', 'END_FINALLY', 'BREAK_LOOP',
+                          'RETURN_VALUE', 'RAISE_VARARGS', 'STOP_CODE',
+                          'POP_EXEPT', 'WITH_CLEANUP', 'WITH_CLEANUP_START',
+                          'WITH_CLEANUP_FINISH', 'SETUP_ASYNC_WITH'}:
+            return True
+
+        elif self.has_jump():
+            return True
+
+        return False

--- a/bytecode/tests/test_cfg.py
+++ b/bytecode/tests/test_cfg.py
@@ -405,7 +405,7 @@ class BytecodeBlocksFunctionalTests(TestCase):
         self.assertEqual(code.co_argcount, 3)
         self.assertEqual(code.co_kwonlyargcount, 2)
         self.assertEqual(code.co_nlocals, 6)
-        self.assertEqual(code.co_stacksize, 1)
+        self.assertEqual(code.co_stacksize, 7)
         # FIXME: don't use hardcoded constants
         self.assertEqual(code.co_flags, 0x43)
         self.assertEqual(code.co_code, expected)


### PR DESCRIPTION
Add stack depth computation based on byteplay implementation. The implementation take some margin with the stack depth (depth is always increased by 6 at the end). This comes from the byteplay implementation. @serprex may know more about this.
I had to modify some tests because the bytecode could not allow computation of the stack depth. I had no way to run the tests on Python 3.6 so the value of the wordcode should be specially checked. 