### PR TITLE
Stack depth computation based on cfg analysis

### DIFF
--- a/TODO.rst
+++ b/TODO.rst
@@ -1,7 +1,5 @@
 * Convert peephole_opt code to a more generic CFG optimizer?
   For example, extract code to remove unreachable blocks?
-* ConcreteBytecode.to_code(): compute the stack level, see byteplay
-  and Python/compile.c?
 * ConcreteBytecode.to_code(): better error reporting on bugs in the code
 * Document or expose CO_xxx flags
 

--- a/bytecode/bytecode.py
+++ b/bytecode/bytecode.py
@@ -8,9 +8,6 @@ class BaseBytecode:
     def __init__(self):
         self.argcount = 0
         self.kwonlyargcount = 0
-        # FIXME: insane and safe value until _ConvertBytecodeToConcrete is able
-        # to compute the value itself
-        self._stacksize = 256
         # FIXME: use something higher level? make it private?
         self.flags = 0
         self.first_lineno = 1
@@ -25,7 +22,6 @@ class BaseBytecode:
     def _copy_attr_from(self, bytecode):
         self.argcount = bytecode.argcount
         self.kwonlyargcount = bytecode.kwonlyargcount
-        self._stacksize = bytecode._stacksize
         self.flags = bytecode.flags
         self.first_lineno = bytecode.first_lineno
         self.name = bytecode.name
@@ -42,7 +38,7 @@ class BaseBytecode:
             return False
         if self.kwonlyargcount != other.kwonlyargcount:
             return False
-        if self._stacksize != other._stacksize:
+        if self.compute_stacksize() != other.compute_stacksize():
             return False
         if self.flags != other.flags:
             return False
@@ -119,6 +115,10 @@ class Bytecode(_InstrList, BaseBytecode):
     def from_code(code):
         concrete = _bytecode.ConcreteBytecode.from_code(code)
         return concrete.to_bytecode()
+
+    def compute_stacksize(self):
+        cfg = _bytecode.ControlFlowGraph.from_bytecode(self)
+        return cfg.compute_stacksize()
 
     def to_code(self):
         return self.to_concrete_bytecode().to_code()

--- a/bytecode/concrete.py
+++ b/bytecode/concrete.py
@@ -208,7 +208,6 @@ class ConcreteBytecode(_bytecode.BaseBytecode, list):
         bytecode.flags = code.co_flags
         bytecode.argcount = code.co_argcount
         bytecode.kwonlyargcount = code.co_kwonlyargcount
-        bytecode._stacksize = code.co_stacksize
         bytecode.first_lineno = code.co_firstlineno
         bytecode.names = list(code.co_names)
         bytecode.consts = list(code.co_consts)
@@ -279,15 +278,20 @@ class ConcreteBytecode(_bytecode.BaseBytecode, list):
 
         return b''.join(lnotab)
 
+    def compute_stacksize(self):
+        bytecode = self.to_bytecode()
+        cfg = _bytecode.ControlFlowGraph.from_bytecode(bytecode)
+        return cfg.compute_stacksize()
+
     def to_code(self):
         code_str, linenos = self._assemble_code()
         lnotab = self._assemble_lnotab(self.first_lineno, linenos)
         nlocals = len(self.varnames)
+        stacksize = self.compute_stacksize()
         return types.CodeType(self.argcount,
                               self.kwonlyargcount,
                               nlocals,
-                              # FIXME: compute stack size
-                              self._stacksize,
+                              stacksize,
                               self.flags,
                               code_str,
                               tuple(self.consts),

--- a/bytecode/instr.py
+++ b/bytecode/instr.py
@@ -1,4 +1,5 @@
 import enum
+import dis
 import math
 import opcode as _opcode
 import types
@@ -268,10 +269,16 @@ class Instr:
     def lineno(self, lineno):
         self._set(self._name, self._arg, lineno)
 
+    @property
+    def stack_effect(self):
+        # All opcodes whose arguments are not represented by integers have
+        # a stack_effect indepent of their argument.
+        arg = (self._arg if isinstance(self._arg, int) else
+               0 if self._opcode >= _opcode.HAVE_ARGUMENT else None)
+        return dis.stack_effect(self._opcode, arg)
+
     def copy(self):
         return self.__class__(self._name, self._arg, lineno=self._lineno)
-
-    # FIXME: stack effect
 
     def __repr__(self):
         if self._arg is not UNSET:

--- a/bytecode/tests/test_concrete.py
+++ b/bytecode/tests/test_concrete.py
@@ -522,13 +522,15 @@ class BytecodeToConcreteTests(TestCase):
         nb_nop = 2**16
         code = Bytecode([Instr("JUMP_ABSOLUTE", label),
                          BigInstr(nb_nop),
-                         label])
+                         label,
+                         Instr('LOAD_CONST', None),
+                         Instr('RETURN_VALUE')])
 
         code_obj = code.to_code()
         if WORDCODE:
-            expected = (b'\x90\x01\x90\x00q\x06' + NOP * nb_nop)
+            expected = b'\x90\x01\x90\x00q\x06' + NOP * nb_nop + b'd\x00S\x00'
         else:
-            expected = (b'\x90\x01\x00q\x06\x00' + NOP * nb_nop)
+            expected = b'\x90\x01\x00q\x06\x00' + NOP * nb_nop + b'd\x00\x00S'
         self.assertEqual(code_obj.co_code, expected)
 
     def test_jumps(self):

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -93,6 +93,11 @@ Instr
       Operation code (``int``). Setting the operation code updates the
       :attr:`name` attribute.
 
+   .. attribute:: stack_effect
+
+       Operation effect on the stack size as computed by
+       :func:`dis.stack_effect`.
+
    .. versionchanged:: 0.3
       The ``op`` attribute was renamed to :attr:`opcode`.
 
@@ -357,6 +362,14 @@ Bytecode
 
       It is based on :meth:`to_concrete_bytecode` and so resolve jump targets.
 
+   .. method:: compute_stacksize() -> int
+
+      Compute the stacksize needed to execute the code. Will raise an
+      exception if the bytecode is invalid.
+
+      This computation requires to build the control flow graph associated with
+      the code.
+
 
 
 ConcreteBytecode
@@ -410,6 +423,14 @@ ConcreteBytecode
    .. method:: to_bytecode() -> Bytecode
 
       Convert to abstract bytecode with abstract instructions.
+
+   .. method:: compute_stacksize() -> int
+
+      Compute the stacksize needed to execute the code. Will raise an
+      exception if the bytecode is invalid.
+
+      This computation requires to build the control flow graph associated with
+      the code.
 
 
 BasicBlock
@@ -506,6 +527,11 @@ ControlFlowGraph
    .. method:: to_bytecode() -> Bytecode
 
       Convert to a bytecode object using labels.
+
+   .. method:: compute_stacksize() -> int
+
+      Compute the stack size required by a bytecode object. Will raise an
+      exception if the bytecode is invalid.
 
 
 Cell and Free Variables

--- a/doc/cfg.rst
+++ b/doc/cfg.rst
@@ -6,6 +6,10 @@ To analyze or optimize existing code, ``bytecode`` provides a
 :class:`ControlFlowGraph` class which is a `control flow graph (CFG)
 <https://en.wikipedia.org/wiki/Control_flow_graph>`_.
 
+The control flow graph is used to perform the stack depth analysis when
+converting to code. Because it is better at identifying dead code than CPython
+it can lead to reduced stack size.
+
 Example
 =======
 

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -1,6 +1,11 @@
 ChangeLog
 =========
 
+Version 0.6
+-----------
+* Add stack depth computation based on control flow graph analysis
+
+
 Version 0.5
 -----------
 
@@ -10,6 +15,7 @@ Version 0.5
 * Documentation: Add a comparison with byteplay and codetransformer.
 * Remove the BaseIntr class: Instr becomes the new base class.
 * Fix PEP 8 issues and check PEP 8 on Travis CI.
+
 
 2016-04-12: Version 0.4
 -----------------------

--- a/doc/todo.rst
+++ b/doc/todo.rst
@@ -4,8 +4,6 @@ TODO list
 * BaseBytecode.flags: use a class for flags?
 * Remove Bytecode.cellvars and Bytecode.freevars?
 * Remove Bytecode.first_lineno? Compute it on conversions.
-* Compute the stack size of an overall bytecode object: Bytecode.to_concrete_bytecode()
-* Add stack effect: use ``opcode.stack_effect(opcode)``
 * Add instruction constants/enums? Example::
 
     from bytecode import instructions as i


### PR DESCRIPTION
This is a new version of the stack depth computation based on CPython implementation using the control flow graph of the code. It has several advantages compared to the previous implementation:
- it is shorter and easier to read
- it is very close to CPython own implementation (https://hg.python.org/cpython/file/tip/Python/compile.c#l4883) as I basically copy-pasted and adapted the C code
- It is very general as the implementation is identical between CPython 2.7 and 3.6 up to some cosmetic change
However it is likely to be slow.
I added some tests comparing to CPython results. Actually one of them is broken : test_nested_try_except_else_finally. I am not yet sure but I suspect it is a bug in the cfg building.

I made stack_effect a property of Instr and added some argument analysis as dis.stack_effect is quite picky on the argument even if it is not involved in the computation. As a side node, adding a Python 2.7 implementation of stack effect will be, I believe, the only modification required to support Python 2.7